### PR TITLE
Added universal newline when reading files

### DIFF
--- a/djredcap/management/subcommands/convert.py
+++ b/djredcap/management/subcommands/convert.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
             raise CommandError('Enter a filename')
 
         json_filename = options.get('json')
-        fin = open(file_name)
+        fin = open(file_name, 'rU')
         dialect = csv.Sniffer().sniff(fin.read(1024))
         fin.seek(0)
         reader = csv.DictReader(fin, fieldnames=header_keys, dialect=dialect)

--- a/djredcap/management/subcommands/fixture.py
+++ b/djredcap/management/subcommands/fixture.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
 
         global __project_name__
         __project_name__ = app_name
-        fin = open(file)
+        fin = open(file, 'rU')
         header_keys = fin.readline().split(',')
         dialect = csv.Sniffer().sniff(fin.read(1024))
         reader = csv.DictReader(fin, fieldnames=header_keys, dialect=dialect)

--- a/djredcap/management/subcommands/inspect.py
+++ b/djredcap/management/subcommands/inspect.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
         if not fileName:
             raise CommandError('Enter a filename')
 
-        fin = open(fileName)
+        fin = open(fileName,'rU')
         dialect = csv.Sniffer().sniff(fin.read(1024))
         fin.seek(0)
         reader = csv.DictReader(fin, fieldnames=header_keys, dialect=dialect)

--- a/djredcap/management/subcommands/models.py
+++ b/djredcap/management/subcommands/models.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         if not file_name:
             raise CommandError('Enter a filename')
 
-        fin = open(file_name)
+        fin = open(file_name, 'rU')
         dialect = csv.Sniffer().sniff(fin.read(1024))
         fin.seek(0)
         reader = csv.DictReader(fin, fieldnames=header_keys, dialect=dialect)

--- a/djredcap/management/subcommands/rjson.py
+++ b/djredcap/management/subcommands/rjson.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
     def handle(self, file_name=None, *args, **options):
         if not file_name:
             raise CommandError('Enter a filename')
-        fin = open(file_name)
+        fin = open(file_name, 'rU')
         dialect = csv.Sniffer().sniff(fin.read(1024))
         fin.seek(0)
         reader = csv.DictReader(fin, fieldnames=header_keys, dialect=dialect)


### PR DESCRIPTION
Added universal newline option when opening CSVs. Universal newline allows .xlsx documents to be read in django-redcap by first converting them to .csv.
