### PR TITLE
Issue 23

### DIFF
--- a/djredcap/management/commands/redcap.py
+++ b/djredcap/management/commands/redcap.py
@@ -1,4 +1,5 @@
 import sys
+from optparse import make_option
 from optparse import NO_DEFAULT, OptionParser
 from django.core.management.base import CommandError, BaseCommand
 from django.core.management.base import handle_default_options

--- a/djredcap/management/subcommands/convert.py
+++ b/djredcap/management/subcommands/convert.py
@@ -39,10 +39,13 @@ class Command(BaseCommand):
     args = 'filename'
 
     json_filename = ''
-
+    # Add a command line option -m allowing the user to set a filename for models.
+    # Filename is relative to the current working directory.
     option_list = BaseCommand.option_list + (
         make_option('--JSON', action='store', dest='json',
                     help='Print a JSON file when using convert, default no'),
+        make_option('-m', '--model-file', dest='model_filename',
+                    help='Filename to which models are written'),
     )
 
     def handle(self, file_name=None, *args, **options):
@@ -59,7 +62,7 @@ class Command(BaseCommand):
 
         file_name = djconvert.csv_2_json(self, reader, file_name)
         file_name1 = file_name
-        djconvert.json_2_dj(self, file_name)
+        djconvert.json_2_dj(self, file_name, options['model_filename'])
         if json_filename:
             os.rename(file_name1, json_filename)
         else:

--- a/djredcap/management/subcommands/djconvert.py
+++ b/djredcap/management/subcommands/djconvert.py
@@ -437,9 +437,13 @@ def generate_json_field(self, row, json_str):
     return json.dumps(data)
 
 
-def json_2_dj(self, file_name):
+def json_2_dj(self, file_name, model_filename):
     new_file_name = remove_file_extension(self, os.path.basename(file_name))
-    fout = open(os.path.join(os.path.dirname(file_name), 'models.py'), 'w+')
+    if model_filename == None:
+        fout = sys.stdout
+    else:
+        fout = open(os.path.join(os.getcwd(), model_filename), 'w+')
+
     fout.write('from %s import models' % self.db_module)
     fout.write('\n')
     fout.write('\n')

--- a/djredcap/management/subcommands/inspect.py
+++ b/djredcap/management/subcommands/inspect.py
@@ -6,6 +6,7 @@ import sys
 import re
 import inflect
 import djconvert
+from optparse import make_option
 from djredcap import _csv
 from django.core.management.base import BaseCommand, CommandError
 
@@ -50,6 +51,12 @@ class Command(BaseCommand):
     requires_model_validation = False
     db_module = 'django.db'
     args = 'filename'
+    # Add a command line option -m allowing the user to set a filename for models.
+    # Filename is relative to the current working directory.
+    option_list = BaseCommand.option_list + (
+        make_option('-m', '--model-file', dest='model_filename',
+                    help='Filename to which models are written'),
+    )
 
     def handle(self, fileName=None, *args, **options):
         if not fileName:
@@ -80,4 +87,4 @@ class Command(BaseCommand):
         
         if fileName.find('.json') == -1:
             fileName = djconvert.csv_2_json(self, reader, fileName)
-        djconvert.json_2_dj(self, fileName)
+        djconvert.json_2_dj(self, fileName, options['model_filename'])

--- a/djredcap/management/subcommands/models.py
+++ b/djredcap/management/subcommands/models.py
@@ -6,6 +6,7 @@ import sys
 import re
 import inflect
 import djconvert
+from optparse import make_option
 from django.core.management.base import BaseCommand, CommandError
 
 header_keys = (
@@ -32,6 +33,12 @@ class Command(BaseCommand):
     requires_model_validation = False
     db_module = 'django.db'
     args = 'filename'
+    # Add a command line option -m allowing the user to set a filename for models.
+    # Filename is relative to the current working directory.
+    option_list = BaseCommand.option_list + (
+        make_option('-m', '--model-file', dest='model_filename',
+                    help='Filename to which models are written'),
+    )
 
     def handle(self, file_name=None, *args, **options):
         if not file_name:
@@ -43,4 +50,4 @@ class Command(BaseCommand):
         reader = csv.DictReader(fin, fieldnames=header_keys, dialect=dialect)
 
         reader.next()
-        fileName = djconvert.json_2_dj(self, file_name)
+        fileName = djconvert.json_2_dj(self, file_name, options['model_filename'])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -33,7 +33,7 @@ class ConvertTestCase(TestCase):
         json_fileName = fileName + '.json'
         shutil.copy(get_filename(json_fileName),get_filename(json_fileName + '2'))
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','convert',get_filename(csv_fileName))
+        call_command('redcap','convert',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename(cmp_fileName))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -46,7 +46,7 @@ class ConvertTestCase(TestCase):
         json_fileName = fileName + '.json'
         shutil.copy(get_filename(json_fileName),get_filename(json_fileName + '2'))
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','convert',get_filename(csv_fileName))
+        call_command('redcap','convert',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename('cmp_' + fileName + '.py'))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -59,7 +59,7 @@ class ConvertTestCase(TestCase):
         json_fileName = fileName + '.json'
         shutil.copy(get_filename(json_fileName),get_filename(json_fileName + '2'))
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','convert',get_filename(csv_fileName))
+        call_command('redcap','convert',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename('cmp_' + fileName + '.py'))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -71,7 +71,7 @@ class ConvertTestCase(TestCase):
         json_fileName = fileName + '.json'
         shutil.copy(get_filename(json_fileName),get_filename(json_fileName + '2'))
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','convert',get_filename(csv_fileName))
+        call_command('redcap','convert',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename('cmp_' + fileName + '.py'))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -84,7 +84,7 @@ class ConvertTestCase(TestCase):
         json_fileName = fileName + '.json'
         shutil.copy(get_filename(json_fileName),get_filename(json_fileName + '2'))
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','convert',get_filename(csv_fileName))
+        call_command('redcap','convert',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename('cmp_' + fileName + '.py'))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -142,7 +142,7 @@ class ModelsTestCase(TestCase):
         fileName = 'multi_form_with_rep_fields'
         csv_fileName = fileName + '.json'
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','models',get_filename(csv_fileName))
+        call_command('redcap','models',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename(cmp_fileName))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -151,7 +151,7 @@ class ModelsTestCase(TestCase):
         fileName = 'single_form_with_rep_fields_start_with_repeat'
         csv_fileName = fileName + '.json'
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','models',get_filename(csv_fileName))
+        call_command('redcap','models',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename(cmp_fileName))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -160,7 +160,7 @@ class ModelsTestCase(TestCase):
         fileName = 'single_form_with_rep_fields_many_nested'
         csv_fileName = fileName + '.json'
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','models',get_filename(csv_fileName))
+        call_command('redcap','models',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename('cmp_' + fileName + '.py'))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -169,7 +169,7 @@ class ModelsTestCase(TestCase):
         fileName = 'multi_form_without_rep_fields'
         csv_fileName = fileName + '.json'
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','models',get_filename(csv_fileName))
+        call_command('redcap','models',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename('cmp_' + fileName + '.py'))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -178,7 +178,7 @@ class ModelsTestCase(TestCase):
         fileName = 'single_form_without_rep_fields'
         csv_fileName = fileName + '.json'
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','models',get_filename(csv_fileName))
+        call_command('redcap','models',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename('cmp_' + fileName + '.py'))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -190,8 +190,7 @@ class FixtureTestCase(TestCase):
         csv_file_name1 = file_name + '.csv'
         csv_file_name2 = file_name + '.json'
         cmp_file_name = 'cmp_' + file_name + '.json'
-        call_command('redcap','fixture',get_filename(csv_file_name1),
-                    get_filename(csv_file_name2),'mysite')
+        call_command('redcap','fixture',get_filename(csv_file_name1), get_filename(csv_file_name2),'mysite', model_filename=os.path.join(os.path.dirname(get_filename(csv_file_name1)), 'models.py'))
         cmp_file = open(get_filename(cmp_file_name))
         for line1, line2 in izip(open(get_filename('fixtures.json'),'r'),
                                     open(get_filename(cmp_file_name),'r')):
@@ -215,7 +214,7 @@ class RedcapTestCase(TestCase):
         fileName = 'multi_form_with_rep_fields'
         csv_fileName = fileName + '.csv'
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','inspect',get_filename(csv_fileName))
+        call_command('redcap','inspect',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename(cmp_fileName))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -224,7 +223,7 @@ class RedcapTestCase(TestCase):
         fileName = 'single_form_with_rep_fields_start_with_repeat'
         csv_fileName = fileName + '.csv'
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','inspect',get_filename(csv_fileName))
+        call_command('redcap','inspect',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename('cmp_' + fileName + '.py'))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -236,7 +235,7 @@ class RedcapTestCase(TestCase):
 #        fileName = 'single_form_with_rep_fields_many_nested'
 #        csv_fileName = fileName + '.csv'
 #        cmp_fileName = 'cmp_' + fileName + '.py'
-#        call_command('redcap','inspect',get_filename(csv_fileName))
+#        call_command('redcap','inspect',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
 #        cmp_file = open(get_filename('cmp_' + fileName + '.py'))
 #        for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
 #            self.assertEqual(line1,line2)
@@ -245,7 +244,7 @@ class RedcapTestCase(TestCase):
         fileName = 'multi_form_without_rep_fields'
         csv_fileName = fileName + '.csv'
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','inspect',get_filename(csv_fileName))
+        call_command('redcap','inspect',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename('cmp_' + fileName + '.py'))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)
@@ -254,7 +253,7 @@ class RedcapTestCase(TestCase):
         fileName = 'single_form_without_rep_fields'
         csv_fileName = fileName + '.csv'
         cmp_fileName = 'cmp_' + fileName + '.py'
-        call_command('redcap','inspect',get_filename(csv_fileName))
+        call_command('redcap','inspect',get_filename(csv_fileName), model_filename=os.path.join(os.path.dirname(get_filename(csv_fileName)), 'models.py'))
         cmp_file = open(get_filename('cmp_' + fileName + '.py'))
         for line1, line2 in izip(open(get_filename('models.py'),'r'),open(get_filename(cmp_fileName),'r')):
             self.assertEqual(line1,line2)


### PR DESCRIPTION
Resolves issue-23 by adding -m option to convert, inspect, and models allowing a filename to be specified for models output. If no filename is specified, models are printed to stdout. json_2_dj now has n additional argument "modelfilename".